### PR TITLE
Allow running Electron app as root

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Electron wrapper for Dungeon Dummies game",
   "main": "main/main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "electron --no-sandbox .",
     "test": "echo \"No tests specified\""
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- run electron with `--no-sandbox` to enable launching when executed as root

## Testing
- `xvfb-run -a npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1198f88f48322bc92f937ebaed899