### PR TITLE
Guard audio init when Web Audio API is missing

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -1212,7 +1212,9 @@ const musicPacks = [
   { type:'triangle', notes:[233.08,261.63,277.18,311.13,349.23,392,415.3] }
 ];
 function initAudio(){
-  if(!audioCtx) audioCtx = new (window.AudioContext||window.webkitAudioContext)();
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  if(!AudioCtx) return;
+  if(!audioCtx) audioCtx = new AudioCtx();
   if(audioCtx.state === 'suspended') audioCtx.resume();
 }
 function playFootstep(){


### PR DESCRIPTION
## Summary
- avoid crashing if the Web Audio API isn't available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b11b8e95088322a738bbf9f2bbd526